### PR TITLE
CameraService: Fix deadlock in binder death cleanup.

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -1781,7 +1781,8 @@ bool CameraService::evictClientIdByRemote(const wp<IBinder>& remote) {
                 ret = true;
             }
         }
-
+        //clear the evicted client list before acquring service lock again.
+        evicted.clear();
         // Reacquire mServiceLock
         mServiceLock.lock();
 


### PR DESCRIPTION
Issue:
In the event of a binder death, there is a chance of deadlock
due to recursive lock acquisition in the death handling sequence.

Fix:
Clear evicted client list before acquiring service lock.

CRs-Fixed: 984249
Change-Id: I6fc5fa6e01c002bc46be058fcd977be14cae0270
Signed-off-by: mydongistiny <jaysonedson@gmail.com>
Signed-off-by: xyyx <xyyx@mail.ru>